### PR TITLE
feat: experimental_backgroundImage support

### DIFF
--- a/android/src/main/java/com/fastsquircle/FastSquircleView.java
+++ b/android/src/main/java/com/fastsquircle/FastSquircleView.java
@@ -12,6 +12,7 @@ import androidx.annotation.OptIn;
 
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.uimanager.drawable.BackgroundDrawable;
+import com.facebook.react.uimanager.drawable.BackgroundImageDrawable;
 import com.facebook.react.uimanager.drawable.BorderDrawable;
 import com.facebook.react.uimanager.drawable.CompositeBackgroundDrawable;
 import com.facebook.react.uimanager.drawable.OutlineDrawable;
@@ -19,6 +20,7 @@ import com.facebook.react.uimanager.drawable.OutsetBoxShadowDrawable;
 import com.facebook.react.uimanager.style.Overflow;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.fastsquircle.drawables.SquircleBackgroundDrawable;
+import com.fastsquircle.drawables.SquircleBackgroundImageDrawable;
 import com.fastsquircle.drawables.SquircleBorderDrawable;
 import com.fastsquircle.drawables.SquircleOutlineDrawable;
 import com.fastsquircle.drawables.SquircleOutsetShadowDrawable;
@@ -31,6 +33,7 @@ public class FastSquircleView extends ReactViewGroup {
   private float cornerSmoothing = 0.0f;
 
   private SquircleBackgroundDrawable squircleBackgroundDrawable;
+  private SquircleBackgroundImageDrawable squircleBackgroundImageDrawable;
   private SquircleBorderDrawable squircleBorderDrawable;
 
   private SquircleOutlineDrawable squircleOutlineDrawable;
@@ -95,6 +98,7 @@ public class FastSquircleView extends ReactViewGroup {
     }
 
     int backgroundDrawableIndex = -1;
+    int backgroundImageDrawableIndex = -1;
     int borderDrawableIndex = -1;
     int outlineDrawableIndex = -1;
     for (int i = 0; i < layerDrawable.getNumberOfLayers(); i++) {
@@ -102,6 +106,10 @@ public class FastSquircleView extends ReactViewGroup {
 
       if (backgroundDrawableIndex < 0 && layer instanceof BackgroundDrawable) {
         backgroundDrawableIndex = i;
+      }
+
+      if (backgroundImageDrawableIndex < 0 && layer instanceof BackgroundImageDrawable) {
+        backgroundImageDrawableIndex = i;
       }
 
       if (borderDrawableIndex < 0 && layer instanceof BorderDrawable) {
@@ -120,6 +128,16 @@ public class FastSquircleView extends ReactViewGroup {
         this.squircleBackgroundDrawable = new SquircleBackgroundDrawable(backgroundDrawable, this.cornerSmoothing);
       } else {
         this.squircleBackgroundDrawable.setBase(backgroundDrawable);
+      }
+    }
+
+    BackgroundImageDrawable backgroundImageDrawable = null;
+    if (backgroundImageDrawableIndex >= 0) {
+      backgroundImageDrawable = (BackgroundImageDrawable) layerDrawable.getDrawable(backgroundImageDrawableIndex);
+      if (this.squircleBackgroundImageDrawable == null) {
+        this.squircleBackgroundImageDrawable = new SquircleBackgroundImageDrawable(backgroundImageDrawable, this.cornerSmoothing);
+      } else {
+        this.squircleBackgroundImageDrawable.setBase(backgroundImageDrawable);
       }
     }
 
@@ -146,12 +164,14 @@ public class FastSquircleView extends ReactViewGroup {
     }
 
     if (backgroundDrawableIndex >= 0) layerDrawable.setDrawable(backgroundDrawableIndex, this.squircleBackgroundDrawable);
+    if (backgroundImageDrawableIndex >= 0) layerDrawable.setDrawable(backgroundImageDrawableIndex, this.squircleBackgroundImageDrawable);
     if (borderDrawableIndex >= 0) layerDrawable.setDrawable(borderDrawableIndex, this.squircleBorderDrawable);
     if (outlineDrawableIndex >= 0) layerDrawable.setDrawable(outlineDrawableIndex, this.squircleOutlineDrawable);
 
     super.draw(canvas);
 
     if (backgroundDrawableIndex >= 0) layerDrawable.setDrawable(backgroundDrawableIndex, backgroundDrawable);
+    if (backgroundImageDrawableIndex >= 0) layerDrawable.setDrawable(backgroundImageDrawableIndex, backgroundImageDrawable);
     if (borderDrawableIndex >= 0) layerDrawable.setDrawable(borderDrawableIndex, borderDrawable);
     if (outlineDrawableIndex >= 0) layerDrawable.setDrawable(outlineDrawableIndex, outlineDrawable);
   }
@@ -162,6 +182,10 @@ public class FastSquircleView extends ReactViewGroup {
 
     if (this.squircleBackgroundDrawable != null) {
       this.squircleBackgroundDrawable.setCornerSmoothing(cornerSmoothing);
+    }
+
+    if (this.squircleBackgroundImageDrawable != null) {
+      this.squircleBackgroundImageDrawable.setCornerSmoothing(cornerSmoothing);
     }
 
     if (this.squircleBorderDrawable != null) {

--- a/android/src/main/java/com/fastsquircle/drawables/SquircleBackgroundImageDrawable.java
+++ b/android/src/main/java/com/fastsquircle/drawables/SquircleBackgroundImageDrawable.java
@@ -1,0 +1,114 @@
+package com.fastsquircle.drawables;
+
+import android.graphics.Canvas;
+import android.graphics.Rect;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.drawable.BackgroundImageDrawable;
+import com.fastsquircle.utils.SquirclePathCalculator;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Wraps BackgroundImageDrawable (RN 0.83+) to render background images/gradients
+ * with squircle corners instead of regular rounded rectangles.
+ */
+public class SquircleBackgroundImageDrawable extends ComposedDrawable {
+
+  private BackgroundImageDrawable base;
+  private float cornerSmoothing;
+
+  public SquircleBackgroundImageDrawable(BackgroundImageDrawable base, float cornerSmoothing) {
+    super(base);
+    this.base = base;
+    this.cornerSmoothing = cornerSmoothing;
+  }
+
+  public void setBase(BackgroundImageDrawable base) {
+    super.updateBase(base);
+    this.base = base;
+  }
+
+  public void setCornerSmoothing(float cornerSmoothing) {
+    this.cornerSmoothing = cornerSmoothing;
+  }
+
+  @Override
+  public void draw(@NonNull Canvas canvas) {
+    var borderRadius = base.getBorderRadius();
+    if (borderRadius == null) {
+      base.draw(canvas);
+      return;
+    }
+
+    var context = getContext();
+    if (context == null) {
+      base.draw(canvas);
+      return;
+    }
+
+    var computedBorderRadius = borderRadius.resolve(
+      getLayoutDirection(),
+      context,
+      PixelUtil.toDIPFromPixel(getBounds().width()),
+      PixelUtil.toDIPFromPixel(getBounds().height())
+    );
+
+    if (computedBorderRadius == null || !computedBorderRadius.hasRoundedBorders()) {
+      base.draw(canvas);
+      return;
+    }
+
+    // Create squircle path and clip to it, then let base draw
+    canvas.save();
+
+    var bounds = getBounds();
+    var squirclePath = SquirclePathCalculator.getPath(
+      computedBorderRadius,
+      bounds.width(),
+      bounds.height(),
+      cornerSmoothing
+    );
+
+    // Clip to the squircle path
+    canvas.clipPath(squirclePath);
+    
+    // Let the base drawable draw itself (which will draw the gradient)
+    // but it will be clipped to our squircle path
+    base.draw(canvas);
+
+    canvas.restore();
+  }
+
+  @Nullable
+  private android.content.Context getContext() {
+    try {
+      Field field = BackgroundImageDrawable.class.getDeclaredField("context");
+      field.setAccessible(true);
+      Object fieldValue = field.get(base);
+      field.setAccessible(false);
+      return (android.content.Context) fieldValue;
+    } catch (NoSuchFieldException | IllegalAccessException | ClassCastException ignored) {
+    }
+    return null;
+  }
+
+  @Override
+  protected void onBoundsChange(@NonNull Rect bounds) {
+    super.onBoundsChange(bounds);
+    if (base == null) return;
+
+    try {
+      Class<?> clazz = base.getClass();
+      Method privateMethod = clazz.getDeclaredMethod("onBoundsChange", Rect.class);
+      privateMethod.setAccessible(true);
+      privateMethod.invoke(base, bounds);
+    } catch (Exception ignored) {
+    }
+  }
+}
+

--- a/ios/FastSquircleView.mm
+++ b/ios/FastSquircleView.mm
@@ -170,6 +170,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   Ivar backgroundColorLayerIvar = class_getInstanceVariable([RCTViewComponentView class], "_backgroundColorLayer");
   CALayer *backgroundColorLayer = object_getIvar(self, backgroundColorLayerIvar);
   
+  Ivar backgroundImageLayersIvar = class_getInstanceVariable([RCTViewComponentView class], "_backgroundImageLayers");
+  NSArray<CALayer *> *backgroundImageLayers = object_getIvar(self, backgroundImageLayersIvar);
+
   Ivar borderLayerIvar = class_getInstanceVariable([RCTViewComponentView class], "_borderLayer");
   CALayer *borderLayer = object_getIvar(self, borderLayerIvar);
   
@@ -225,6 +228,16 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _squircleBackgroundLayer.mask = maskLayer;
     _squircleBackgroundLayer.backgroundColor = originalBackgroundColor;
     [_squircleBackgroundLayer removeAllAnimations];
+  }
+  
+  // background image layers (gradients, images, etc.)
+  if (backgroundImageLayers && backgroundImageLayers.count > 0) {
+    for (CALayer *backgroundImageLayer in backgroundImageLayers) {
+      CAShapeLayer *backgroundImageMaskLayer = [[CAShapeLayer alloc] init];
+      backgroundImageMaskLayer.path = squirclePath.CGPath;
+      backgroundImageLayer.mask = backgroundImageMaskLayer;
+      [backgroundImageLayer removeAllAnimations];
+    }
   }
   
   // border


### PR DESCRIPTION
Add support for `experimental_backgroundImage` style.
<img width="432" height="944" alt="image" src="https://github.com/user-attachments/assets/10a99821-5848-4ff3-9fc9-dc13ef06baa3" />
<img width="417" height="837" alt="image" src="https://github.com/user-attachments/assets/a1711bad-1664-4ff0-a029-3c0a8a6c27f8" />


+ Fix boxShadow calculation on IOS rn81+