### PR TITLE
refactor: move version_flags from deprecated s.xcconfig to s.pod_target_xcconfig

### DIFF
--- a/FastSquircle.podspec
+++ b/FastSquircle.podspec
@@ -23,11 +23,8 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'SWIFT_COMPILATION_MODE' => 'wholemodule'
-  }
-
-  s.xcconfig = {
-    "OTHER_CFLAGS" => "$(inherited) #{version_flags}",
+    'SWIFT_COMPILATION_MODE' => 'wholemodule',
+    'OTHER_CFLAGS' => "$(inherited) #{version_flags}"
   }
 
   install_modules_dependencies(s)


### PR DESCRIPTION
## Summary

  Replaces the deprecated `s.xcconfig` with `s.pod_target_xcconfig` for version_flags in
  FastSquircle.podspec.

  s.xcconfig has been deprecated since CocoaPods 0.38 in favor of the explicit
  `pod_target_xcconfig` / `user_target_xcconfig split`.

  Related: #24

  ## Test plan

  1. pod install
  2. Build succeeds