### PR TITLE
fix(ios): namespace podspec Ruby helpers to avoid reanimated collision

### DIFF
--- a/FastSquircle.podspec
+++ b/FastSquircle.podspec
@@ -3,7 +3,7 @@ require_relative './scripts/cocoapods_utils'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-$config = find_config()
+$config = fast_squircle_find_config()
 version_flags = "-DREACT_NATIVE_MINOR_VERSION=#{$config[:react_native_minor_version]}"
 
 Pod::Spec.new do |s|

--- a/scripts/cocoapods_utils.rb
+++ b/scripts/cocoapods_utils.rb
@@ -1,4 +1,4 @@
-def try_to_parse_react_native_package_json(node_modules_dir)
+def fast_squircle_try_to_parse_react_native_package_json(node_modules_dir)
   react_native_package_json_path = File.join(node_modules_dir, 'react-native/package.json')
   if !File.exist?(react_native_package_json_path)
     return nil
@@ -6,19 +6,19 @@ def try_to_parse_react_native_package_json(node_modules_dir)
   return JSON.parse(File.read(react_native_package_json_path))
 end
 
-def find_config()
+def fast_squircle_find_config()
   result = {
     :react_native_version => nil,
     :react_native_minor_version => nil,
   }
 
   react_native_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
-  react_native_json = try_to_parse_react_native_package_json(react_native_node_modules_dir)
+  react_native_json = fast_squircle_try_to_parse_react_native_package_json(react_native_node_modules_dir)
 
   if react_native_json == nil
     # user configuration, just in case
     node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-    react_native_json = try_to_parse_react_native_package_json(node_modules_dir)
+    react_native_json = fast_squircle_try_to_parse_react_native_package_json(node_modules_dir)
   end
 
   if react_native_json == nil


### PR DESCRIPTION
Top-level find_config in cocoapods_utils.rb shadows react-native-reanimated's identically named helper during pod install, leaving REACT_NATIVE_MINOR_VERSION empty in the generated xcconfig. Ref https://github.com/fbeccaceci/react-native-fast-squircle/issues/26